### PR TITLE
Nim 1.2 - base64.encode no longer supports lineLen, use base64.encodeMIME

### DIFF
--- a/mime.nim
+++ b/mime.nim
@@ -237,7 +237,7 @@ proc mimeEncoder*(txt: string, encoder: ContentTransferEncoders,
   case encoder
   of NO_ENCODING: return txt
   of QUOTED_PRINTABLES: txtbuf = txt.quoted(srcEncoding, newlineAt = maxLine)
-  of BASE64: txtbuf = txt.encode(lineLen = maxLine)
+  of BASE64: txtbuf = txt.encodeMIME(lineLen = maxLine)
   if forHeader:
     let shortname = ($encoder)[0] # since 'Q'uoted.. / 'B'ase64.
     return "=?$#?$#?$#?=" % @[srcEncoding, $shortname, txtbuf]

--- a/mime.nimble
+++ b/mime.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.0.2"
+version       = "0.0.3"
 author        = "enthus1ast"
 description   = "mime generator (email with attachments)"
 license       = "MIT"
@@ -7,4 +7,4 @@ installDirs   = @["src"]
 
 # Dependencies
 
-requires "nim >= 1.0.0"
+requires "nim >= 1.2.0"


### PR DESCRIPTION
Fix https://github.com/enthus1ast/nimMime/issues/4